### PR TITLE
Zaadoptuj kramdown (porzucamy redcarpet).

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,52 +1,61 @@
 # Wakacje z MD
 
-To repozytorium zawiera kod strony [wakacjezmd.github.io](http://wakacjezmd.github.io), na której znajdują się rozwiązania kolokwiów oraz egzaminów z Matematyki Dyskretnej prowadzonej na wydziale [Matematyki, Informatyki i Mechaniki UW](http://www.mimuw.edu.pl).
+To repozytorium zawiera kod strony [wakacjezmd.github.io], na której znajdują
+się rozwiązania kolokwiów oraz egzaminów z Matematyki Dyskretnej prowadzonej
+na wydziale [Matematyki, Informatyki i Mechaniki UW].
 
 ## Generowanie strony
 
-Do generowania zawartości strony potrzebny jest [jekyll](http://jekyllrb.com) i [redcarpet](https://github.com/vmg/redcarpet). Żeby je zainstalować trzeba ściągnąć ruby i wpisać:
-```
+Do generowania zawartości strony potrzebny jest [jekyll]. Żeby je zainstalować
+trzeba ściągnąć Ruby i wpisać:
+
+```sh
 (sudo) gem install jekyll
-(sudo) gem install redcarpet
 ```
-Po wprowadzeniu zmian w repozytorium dobrze jest włączyć `jekyll serve` z katalogu
-głównego i przed pushem sprawdzić lokalnie czy wszystko działa.
+
+Po wprowadzeniu zmian w repozytorium dobrze jest włączyć `jekyll serve`
+z katalogu głównego i przed pushem sprawdzić lokalnie czy wszystko działa.
 
 ## Błędy
 
-Wszystkie błędy można zgłaszać na stronie [issues](https://github.com/wakacjezmd/wakacjezmd.github.io/issues).
+Wszystkie błędy można zgłaszać na stronie [issues].
 
 ## Pliki z rozwiązaniami
 
-W katalogu `_solutions` znajdują się rozwiązania wszystkich egzaminów i kolokwiów podzielone podkatalogami na odpowiednie lata.
+W katalogu `_solutions` znajdują się rozwiązania wszystkich egzaminów
+i kolokwiów podzielone podkatalogami na odpowiednie lata.
 
-Format nazw plików egzaminów powinien spełniać poniższe reguły: `<rok>-egzamin-<nr>.md`.
+Format nazw plików egzaminów powinien spełniać poniższe reguły:
+`<rok>-egzamin-<nr>.md`.
 
 ## Dodawanie rozwiązań
 
 #### LaTeX
 
-We wszystkich plikach można używać LaTeXa. Wzory inline należy umieszczać w nawiasach `\(<wzór>\)`, a wzory mające być wyświetlane w oddzielnych liniach w znacznikach `$$<wzór>$$`.
+We wszystkich plikach można używać LaTeXa. Wzory inline należy umieszczać
+w nawiasach `\(<wzór>\)`, a wzory mające być wyświetlane w oddzielnych liniach
+w znacznikach `$$<wzór>$$`.
 
-**Przydatne wzory**
+#### Przydatne wzory
 
-* Liczby Stirlinga I rodzaju `{ n\brack m }`
-* Liczby Stirlinga II rodzaju `{ n\brace m }`
+* liczby Stirlinga I rodzaju `{ n\brack m }`
+* liczby Stirlinga II rodzaju `{ n\brace m }`
 
-**UWAGA**
+#### UWAGA
 
-Niestety parser markdown inaczej interpretuje tekst umieszczony w tagach HTML (np. rozwiązania), a
-inaczej ten umieszczony normalnie w pliku.
+Niestety parser Markdown inaczej interpretuje tekst umieszczony w tagach HTML
+(np. rozwiązania), a inaczej ten umieszczony normalnie w pliku.
 
-* W treści zadania `_` jest interpretowany jako kursywa, więc we wszystkich wzorach trzeba
-wpisywać `\_`.
-* W treści zadania `\` jest interpretowany jako escapowanie kolejnego znaku, więc jeżeli chcemy dodać blok
-LaTeXa inline to należy napisać `\\(<wzór>\\)`.
+* W treści zadania `_` jest interpretowany jako kursywa, więc we wszystkich
+wzorach trzeba wpisywać `\_`.
+* W treści zadania `\` jest interpretowany jako escapowanie kolejnego znaku,
+więc jeżeli chcemy dodać blok LaTeXa inline to należy napisać `\\(<wzór>\\)`.
 
 #### Nagłówek
+
 Plik egzaminu bądź kolokwium powinien posiadać odpowiedni nagłówek:
 
-```
+```md
 ---
 layout: page
 permalink: <link do strony>
@@ -59,8 +68,9 @@ Link do egzaminów powinien mieć format `/<rok>/egzamin/<nr>/`.
 
 Markdown każdego zadania powinien mieć następującą strukturę:
 
-```
-###Zadanie <NR>
+```md
+### Zadanie <NR>
+
 <TREŚĆ>
 
 <div data-collapse>
@@ -84,3 +94,10 @@ Markdown każdego zadania powinien mieć następującą strukturę:
 #### Nowy egzamin
 
 Po dodaniu nowego pliku egzaminu należy dodać odpowiednie linki w `index.html`.
+
+[issues]: https://github.com/wakacjezmd/wakacjezmd.github.io/issues
+[jekyll]: http://jekyllrb.com
+[Matematyki, Informatyki i Mechaniki UW]: http://www.mimuw.edu.pl
+[wakacjezmd.github.io]: http://wakacjezmd.github.io
+
+

--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ url: "http://wakacjezmd.github.io"
 github_username:  wakacjezmd
 
 # Build settings
-markdown: redcarpet
+markdown: kramdown
 permalink: pretty
 
 # Includes

--- a/_solutions/2006/2006-egzamin-1.md
+++ b/_solutions/2006/2006-egzamin-1.md
@@ -5,42 +5,59 @@ permalink: /2006/egzamin/1/
 
 ## 2006 Pierwszy termin
 
-###Zadanie 1
+### Zadanie 1
 
-*Uporządkowany podział* liczby \\(n\\) to ciąg dodatnich liczb całkowitych \\( \langle s\_{1}, \ldots, s\_{k} \rangle \\) takich, że \\(\sum\_{i=1}^{k}s\_{i} = n \\). Na przykład, wszystkie
-uporządkowane podziały liczby 3 to \\( \langle 1,1,1 \rangle \\), \\( \langle 1,2 \rangle \\),
+*Uporządkowany podział* liczby \\(n\\) to ciąg dodatnich liczb całkowitych
+\\( \langle s\_{1}, \ldots, s\_{k} \rangle \\) takich, że
+\\(\sum\_{i=1}^{k}s\_{i} = n \\). Na przykład, wszystkie uporządkowane podziały
+liczby 3 to \\( \langle 1,1,1 \rangle \\), \\( \langle 1,2 \rangle \\),
 \\( \langle 2,1 \rangle \\), \\( \langle 3 \rangle \\).
 
-**(a)** Znajdź liczbę wszystkich uporządkowanych podziałów \\(n\\).<br/>
-**(b)** Udowodnij, że dla \\( n \geq 4 \\) we wszystkich uporządkowanych podziałach \\(n\\) liczba \\(3n\\)
-występuje dokłądnie \\( n2^{n-5} \\) razy.
+**(a)** Znajdź liczbę wszystkich uporządkowanych podziałów \\(n\\).
+
+**(b)** Udowodnij, że dla \\( n \geq 4 \\) we wszystkich uporządkowanych
+podziałach \\(n\\) liczba \\(3n\\) występuje dokłądnie \\( n2^{n-5} \\) razy.
 
 ---
 
-###Zadanie 3
+### Zadanie 3
 
-Udowodnij, że krawędzie dowolnego grafu nieskierowanego można skierować w taki sposób,
-że dla każdego wierzchołka \\(v\\) będzie spełniony warunek \\( \left| deg\_{in}(v) - deg\_{out}(v) \right|  \leq 1 \\).
+Udowodnij, że krawędzie dowolnego grafu nieskierowanego można skierować w taki
+sposób, że dla każdego wierzchołka \\(v\\) będzie spełniony warunek
+\\( \left| deg\_{in}(v) - deg\_{out}(v) \right|  \leq 1 \\).
 
 <div data-collapse>
   <h4 class="collapsible">Rozwiązanie</h4>
   <div class="solution">
     <p>
-      Zauważmy, że jeżeli graf \(G\) zawiera podgraf \(C\) będący cyklem, to krawędzie zawarte w \(C\) możemy
-      zorientować tak, żeby zachodziło \(\forall{v \in V(C)}\ \left| deg_{in}(v) - deg_{out}(v) \right| = 0\),
+      Zauważmy, że jeżeli graf \(G\) zawiera podgraf \(C\) będący cyklem, to
+      krawędzie zawarte w \(C\) możemy zorientować tak, żeby zachodziło
+      \(\forall{v \in V(C)}\ \left| deg_{in}(v) - deg_{out}(v) \right| = 0\),
       bo do dowolnego wierzchołka \(v\) wchodzą dokładnie dwie krawędzie.
     </p>
     <p>
-      Możemy więc założyć, że w \(G\) nie ma już żadnych cykli, czyli że jest drzewem.
-      Przeprowadźmy indukcje po liczbie wierzchołków.<br/>
-      1. Jeżeli drzewo ma jeden wierzchołek, to spełnia on warunek.<br/>
-      2. Załóżmy, że warunek jest prawdziwy dla wszystkich drzew \(n\)-wierzchołkowych.
-         Weźmy dowolne drzewo o \(n+1\) wierzchołkach i wybierzmy jeden z jego liści.
-         Możemy go usunąć i z założenia indukcyjnego skierować pozostałe krawędzie tak,
-         żeby spełniały powyższy warunek. Następnie dodajemy go, a kierunek jego krawędzi zawsze możemy
-         ustalić tak, żeby albo wyrównać stopnie wchodzące i wychodzące jego sąsiada (jeżeli ich różnica była inna niż 0),
-         albo, jeżeli były równe, to po skierowaniu tej krawędzi ich różnica będzie wynosiła co najwyżej 1. Zatem
-         takie drzewo też spełnia warunek zadania.
+      Możemy więc założyć, że w \(G\) nie ma już żadnych cykli, czyli że jest
+      drzewem. Przeprowadźmy indukcje po liczbie wierzchołków.
+    </p>
+    <p>
+    <ol>
+    <li>
+      Jeżeli drzewo ma jeden wierzchołek, to spełnia on warunek.
+    </li>
+    <li>
+      Załóżmy, że warunek jest prawdziwy dla wszystkich drzew
+      \(n\)-wierzchołkowych.  Weźmy dowolne drzewo o \(n+1\) wierzchołkach
+      i wybierzmy jeden z jego liści.  Możemy go usunąć i z założenia
+      indukcyjnego skierować pozostałe krawędzie tak, żeby spełniały powyższy
+      warunek. Następnie dodajemy go, a kierunek jego krawędzi zawsze możemy
+      ustalić tak, żeby albo wyrównać stopnie wchodzące i wychodzące jego
+      sąsiada (jeżeli ich różnica była inna niż 0), albo, jeżeli były równe, to
+      po skierowaniu tej krawędzi ich różnica będzie wynosiła co najwyżej 1.
+      Zatem takie drzewo też spełnia warunek zadania.
+    </li>
+    </ol>
     </p>
   </div>
 </div>
+
+---

--- a/_solutions/2006/2006-egzamin-2.md
+++ b/_solutions/2006/2006-egzamin-2.md
@@ -5,21 +5,47 @@ permalink: /2006/egzamin/2/
 
 ## 2006 Drugi termin
 
-###Zadanie 3
+### Zadanie 3
 
 Udowodnij tożsamość:
-$$\frac{z^n}{(1-z)(1-2z)...(1-nz)}=\sum_{k}{ k\brace n }z^k$$
+$$
+\frac{z^n}{(1-z)(1-2z)...(1-nz)}=\sum_{k}{ k\brace n }z^k
+$$
 
 
 <div data-collapse>
   <h4 class="collapsible">Rozwiązanie</h4>
   <div class="solution">
     <p>
-      Zadanie polega na tym, by udowodnić, że lewa strona to funkcja tworząca liczb \({ k\brace n }\) dla ustalonego n. Można to zrobić przez indukcję.<br><br>
-      
-      Zauważmy, że dla \(n=0\) lewa strona to \(1\), czyli funkcja jest tworząca dla \({ k\brace 0 } = [k = 0]\). Warunek bazowy jest spełniony. Teraz załóżmy, że funkcja \(\frac{z^{n-1}}{(1-z)(1-2z)...(1-(n-1)z)}\) to funkcja tworząca \({ k\brace n-1 }\) (założenie indukcyjne). Wtedy: $$\sum_{k}{ k\brace n }z^k=\sum_{k}(n { k-1\brace n } + { k-1\brace n-1 })z^k=nz\sum_{k}{ k-1\brace n}z^{k-1}+z\sum_{k}{ k-1\brace n-1}z^{k-1}=$$$$=nz\sum_{k}{ k\brace n}z^{k}+z\sum_{k}{ k\brace n-1}z^{k}$$
-
-      W przejściu pierwszym skorzystaliśmy z rekurencji dla liczb Stirlinga. Oznaczmy teraz \(\sum_{k}{ k\brace n }z^k = f(z)\). Wtedy (założenie indukcyjne): $$f(z)=nzf(z)+z\frac{z^{n-1}}{(1-z)(1-2z)...(1-(n-1)z)} \iff (1-nz)f(z)=\frac{z^{n}}{(1-z)(1-2z)...(1-(n-1)z)}$$ Po przerzuceniu \((1-nz)\) na prawą stronę otrzymujemy szukaną tożsamość.
+      Zadanie polega na tym, by udowodnić, że lewa strona to funkcja tworząca
+      liczb \({ k\brace n }\) dla ustalonego \(n\). Można to zrobić przez
+      indukcję.
+    </p>
+    <p>
+      Zauważmy, że dla \(n=0\) lewa strona to \(1\), czyli funkcja jest
+      tworząca dla \({ k\brace 0 } = [k = 0]\). Warunek bazowy jest spełniony.
+      Teraz załóżmy, że funkcja \(\frac{z^{n-1}}{(1-z)(1-2z)...(1-(n-1)z)}\), to
+      funkcja tworząca \({ k\brace n-1 }\) (założenie indukcyjne). Wtedy:
+      $$
+      \sum_{k}{ k\brace n }z^k =
+      \sum_{k}(n { k-1\brace n } + { k-1\brace n-1 })z^k =
+      nz\sum_{k}{ k-1\brace n}z^{k-1}+z\sum_{k}{ k-1\brace n-1}z^{k-1} =
+      $$
+      $$
+      = nz\sum_{k}{ k\brace n}z^{k}+z\sum_{k}{ k\brace n-1}z^{k}
+      $$
+    </p>
+    <p>
+      W przejściu pierwszym skorzystaliśmy z rekurencji dla liczb Stirlinga.
+      Oznaczmy teraz \(\sum_{k}{ k\brace n }z^k = f(z)\). Wtedy (założenie
+      indukcyjne):
+      $$
+      f(z)=nzf(z)+z\frac{z^{n-1}}{(1-z)(1-2z)...(1-(n-1)z)} \iff
+      (1-nz)f(z)=\frac{z^{n}}{(1-z)(1-2z)...(1-(n-1)z)}
+      $$
+      Po przerzuceniu \((1-nz)\) na prawą stronę otrzymujemy szukaną tożsamość.
     </p>
   </div>
 </div>
+
+---

--- a/_solutions/2010/2010-egzamin-2.md
+++ b/_solutions/2010/2010-egzamin-2.md
@@ -5,41 +5,59 @@ permalink: /2010/egzamin/2/
 
 ## 2010 Egzamin poprawkowy
 
-###Zadanie 2
+### Zadanie 2
 
-Niech \\(c(V,T)\\) oznacza liczbę spójnych składowych grafu o zbiorze wierzchołków \\(V\\) i zbiorze krawędzi \\(T\\) i niech
-\\(P_g (x)\\) oznacza wielomian chromatyczny grafu \\(G\\). Udowodnij, że:
+Niech \\(c(V,T)\\) oznacza liczbę spójnych składowych grafu o zbiorze
+wierzchołków \\(V\\) i zbiorze krawędzi \\(T\\) i niech \\(P_g (x)\\) oznacza
+wielomian chromatyczny grafu \\(G\\). Udowodnij, że:
 
-**a)** $$ P\_g (x) = \sum\_{T \subseteq E(G)} (-1)^{|T|} x^{c(V(G), T)} $$
+**a)**
+$$
+P\_g (x) = \sum\_{T \subseteq E(G)} (-1)^{|T|} x^{c(V(G), T)}
+$$
+
 *WSKAZÓWKA: Użyj zasady włączania-wyłączania*
 
-
-**b)** Udowodnij, że wartość \\(P_{G}^{'} (0)\\) jest równa różnicy spójnych grafów rozpinających \\(G\\) o odpowiednio parzystej
-i nieparzystej liczbie krawędzi.
+**b)** Udowodnij, że wartość \\(P_{G}^{'} (0)\\) jest równa różnicy spójnych
+grafów rozpinających \\(G\\) o odpowiednio parzystej i nieparzystej liczbie
+krawędzi.
 
 <div data-collapse>
   <h4 class="collapsible">Rozwiązanie</h4>
   <div class="solution">
     <p>
- 	Niech naszym uniwersum \(X\) będą kolorowania grafu \(G\).
-	Niech zdarzeniem \(A_e\) będzie to, że końce krawędzi \(e\) mają jednakowy kolor.
-	Zastanówmy się co to jest \(S_j\). Jest to ilość kolorowań posiadających dokładnie \(j\) własności.
-	To znaczy, że \(j\) krawędzie ma końce tego samego koloru.
-	Ilość takich kolorowań jest równa \( \sum_{T \subseteq G \wedge |T|=2} x^{c(V(G), T)} \),
-	ponieważ wszystkie wierzchołki wewnątrz SS muszą mieć ten sam kolor, a każdą SS możemy kolorować niezależnie
-	na jeden z x kolorów.
-
-	W tym momencie korzystamy ze wzoru na ilość elementów posiadających 0 własności - da to nam ilość
-	kolorowań wierzchołkowych grafu na x kolorów - czyli nasz wielomian chromatyczny ;). Jest to
-	$$ D(0) = \sum_{j} (-1)^j S_j = \sum_{T \subseteq E(G)} (-1)^{|T|} x^{c(V(G), T)} $$
-
-	Drugi podpunkt jest prostszy. Zauważmy że jak policzymy pochodną i przyłożymy \( x = 0 \) to zostaną
-	nam we wzorze jedynie wyrazy w których po policzeniu pochodnej nie było \(x\), czyli takie gdzie
-	\(x\) był w pierwszej potędze. Czyli ilość spójnych składowych danego podgrafu \(T\) była równa jeden.
-	Czyli \(T\) rozpina \(G\).
-
-	Wybrany wyraz będzie pomnożony przez \( (-1)^{|T|} \) zatem gdy ilość krawędzi parzysta to \(1\),
-	a jak nieparzysta to \(-1\). Sumując po wszystkich takich \(T\) dostajemy dokładnie to o co było pytanie w zadaniu.
+      Niech naszym uniwersum \(X\) będą kolorowania grafu \(G\).
+      Niech zdarzeniem \(A_e\) będzie to, że końce krawędzi \(e\) mają jednakowy
+      kolor.  Zastanówmy się co to jest \(S_j\). Jest to ilość kolorowań
+      posiadających dokładnie \(j\) własności.  To znaczy, że \(j\) krawędzie ma
+      końce tego samego koloru.  Ilość takich kolorowań jest równa
+      \( \sum_{T \subseteq G \wedge |T|=2} x^{c(V(G), T)} \), ponieważ wszystkie
+      wierzchołki wewnątrz SS muszą mieć ten sam kolor, a każdą SS możemy
+      kolorować niezależnie na jeden z x kolorów.
+    </p>
+    <p>
+      W tym momencie korzystamy ze wzoru na ilość elementów posiadających 0
+      własności - da to nam ilość kolorowań wierzchołkowych grafu na x kolorów -
+      czyli nasz wielomian chromatyczny ;). Jest to
+      $$
+      D(0) = \sum_{j} (-1)^j S_j =
+      \sum_{T \subseteq E(G)} (-1)^{|T|} x^{c(V(G), T)}
+      $$
+    </p>
+    <p>
+      Drugi podpunkt jest prostszy. Zauważmy że jak policzymy pochodną i
+      przyłożymy \( x = 0 \) to zostaną nam we wzorze jedynie wyrazy w których
+      po policzeniu pochodnej nie było \(x\), czyli takie gdzie \(x\) był w
+      pierwszej potędze. Czyli ilość spójnych składowych danego podgrafu \(T\)
+      była równa jeden. Czyli \(T\) rozpina \(G\).
+    </p>
+    <p>
+      Wybrany wyraz będzie pomnożony przez \( (-1)^{|T|} \) zatem gdy ilość
+      krawędzi parzysta to \(1\), a jak nieparzysta to \(-1\). Sumując po
+      wszystkich takich \(T\) dostajemy dokładnie to o co było pytanie w
+      zadaniu.
     </p>
   </div>
 </div>
+
+---

--- a/_solutions/2011/2011-egzamin-1.md
+++ b/_solutions/2011/2011-egzamin-1.md
@@ -5,14 +5,15 @@ permalink: /2011/egzamin/1/
 
 ## 2011 Egzamin
 
-###Zadanie 1
+### Zadanie 1
 
 Niech \\(b\_r (n,k)\\) oznacza liczbę \\(n\\)-permutacji o \\(k\\) cyklach, w
 których wszystkie liczby \\(1,2,...,r\\) są w jednym cyklu. Udowodnij, że dla
 \\(n \geq r\\) mamy:
 
 $$
-\sum\limits\_{k=1}^n b\_r (n,k) x^k = (r-1)! \frac{x^\overline{n}}{(x+1)^\overline{r-1} }
+\sum\limits\_{k=1}^n b\_r (n,k) x^k =
+(r-1)! \frac{x^\overline{n}}{(x+1)^\overline{r-1} }
 $$
 
 *WSKAZÓWKA: Indukcja.*
@@ -41,16 +42,19 @@ $$
 
       $$
       \sum\limits_{k=1}^{n+1} b_r (n+1,k) x^k = \\
-      n \sum\limits_{k=1}^{n+1} b_r (n,k) x^k + \sum\limits_{k=1}^{n+1} b_r (n,k-1) x^k = \\
-      n \sum\limits_{k=1}^{n} b_r (n,k) x^k + \sum\limits_{k=0}^{n} b_r(n,k)x^{k+1} = \\
-      n \sum\limits_{k=1}^{n} b_r (n,k) x^k + x \sum\limits_{k=1}^{n} b_r(n,k)x^{k} = \\
+      n \sum\limits_{k=1}^{n+1} b_r (n,k) x^k
+        + \sum\limits_{k=1}^{n+1} b_r (n,k-1) x^k = \\
+      n \sum\limits_{k=1}^{n} b_r (n,k) x^k
+        + \sum\limits_{k=0}^{n} b_r(n,k)x^{k+1} = \\
+      n \sum\limits_{k=1}^{n} b_r (n,k) x^k
+        + x \sum\limits_{k=1}^{n} b_r(n,k)x^{k} = \\
       (n+x) (r-1)! \frac{x^\overline{n}}{(x+1)^\overline{r-1}} = \\
       (r-1)! \frac{x^\overline{n+1}}{(x+1)^\overline{r-1}}
       $$
 
       Pierwsza równość została otrzymana poprzez zastosowanie obserwacji. Druga
       poprzez usunięcie wyrazu zerowego z pierwszej sumy oraz przeindeksowanie
-      drugiej.  Trzecia poprzez wyrzucenie zerowego wyrazu z drugiej sumy.
+      drugiej. Trzecia poprzez wyrzucenie zerowego wyrazu z drugiej sumy.
       Kolejne równości to zastosowanie założenia indukcyjnego i proste rachunki
       na silniach.
     </p>

--- a/_solutions/2013/2013-egzamin-1.md
+++ b/_solutions/2013/2013-egzamin-1.md
@@ -5,7 +5,7 @@ permalink: /2013/egzamin/1/
 
 ## 2013 Pierwszy termin
 
-###Zadanie 3
+### Zadanie 3
 
 Rozwiąż kongruencję \\(x^{59} \equiv 604 \ (mod\ 2013)\\)
 
@@ -13,43 +13,85 @@ Rozwiąż kongruencję \\(x^{59} \equiv 604 \ (mod\ 2013)\\)
   <h4 class="collapsible">Rozwiązanie</h4>
   <div class="solution">
     <p>
-      Wiemy, że \( 2013 = 3 \cdot 11 \cdot 61\), \(\phi(p) = p-1 \) (dla \(p\) będącej liczbą pierwszą), a kongruencja w treści jest równoważna poniższemu układowi:
-      $$\left\{
-          \begin{array}{lr}
-            x^{59} \equiv 604\ (mod\ 3) \equiv 1\ (mod\ 3)\\
-            x^{59} \equiv 604\ (mod\ 11) \equiv 10\ (mod\ 11)\\
-            x^{59} \equiv 604\ (mod\ 61) \equiv 55\ (mod\ 61)
-          \end{array}
-        \right.$$
+      Wiemy, że \( 2013 = 3 \cdot 11 \cdot 61\), \(\phi(p) = p-1 \) (dla \(p\)
+      będącej liczbą pierwszą), a kongruencja w treści jest równoważna
+      poniższemu układowi:
+      $$
+      \left\{
+        \begin{array}{lr}
+          x^{59} \equiv 604\ (mod\ 3) \equiv 1\ (mod\ 3)\\
+          x^{59} \equiv 604\ (mod\ 11) \equiv 10\ (mod\ 11)\\
+          x^{59} \equiv 604\ (mod\ 61) \equiv 55\ (mod\ 61)
+        \end{array}
+      \right.
+      $$
     </p>
     <p>
-      \((1)\)<br/>
-      $$x^{2} \equiv 1\ (mod\ 3) \Rightarrow x^{58} \equiv 1\ (mod\ 3)$$
-      $$x^{59} \equiv 1\ (mod\ 3)$$
-      $$x \equiv 1\ (mod\ 3)$$
-      \((2)\)<br/>
-      $$x^{10} \equiv 1\ (mod\ 11) \Rightarrow x^{60} \equiv 1\ (mod\ 11)$$
-      $$x^{59} \equiv 10\ (mod\ 11)$$
-      $$x \equiv 10^{-1}\ (mod\ 11) \equiv 10\ (mod\ 11)$$
-      \((3)\)<br/>
-      $$x^{60} \equiv 1\ (mod\ 61)$$
-      $$x^{59} \equiv 55\ (mod\ 61)$$
-      $$x \equiv 55^{-1}\ (mod\ 61) \equiv 10\ (mod\ 61)$$
+      \((1)\)
+    </p>
+    <p>
+      $$
+      x^{2} \equiv 1\ (mod\ 3) \Rightarrow x^{58} \equiv 1\ (mod\ 3)
+      $$
+      $$
+      x^{59} \equiv 1\ (mod\ 3)
+      $$
+      $$
+      x \equiv 1\ (mod\ 3)
+      $$
+    </p>
+    <p>
+      \((2)\)
+    </p>
+    <p>
+      $$
+      x^{10} \equiv 1\ (mod\ 11) \Rightarrow x^{60} \equiv 1\ (mod\ 11)
+      $$
+      $$
+      x^{59} \equiv 10\ (mod\ 11)
+      $$
+      $$
+      x \equiv 10^{-1}\ (mod\ 11) \equiv 10\ (mod\ 11)
+      $$
+    </p>
+    <p>
+      \((3)\)
+    </p>
+    <p>
+      $$
+      x^{60} \equiv 1\ (mod\ 61)
+      $$
+      $$
+      x^{59} \equiv 55\ (mod\ 61)
+      $$
+      $$
+      x \equiv 55^{-1}\ (mod\ 61) \equiv 10\ (mod\ 61)
+      $$
     </p>
     <p>
       Otrzymujemy układ kongruencji:
-      $$\left\{
-          \begin{array}{lr}
-            x \equiv 1\ (mod\ 3)\\
-            x \equiv 10\ (mod\ 11)\\
-            x \equiv 10\ (mod\ 61)
-          \end{array}
-        \right.$$
+      $$
+      \left\{
+        \begin{array}{lr}
+          x \equiv 1\ (mod\ 3)\\
+          x \equiv 10\ (mod\ 11)\\
+          x \equiv 10\ (mod\ 61)
+        \end{array}
+      \right.
+      $$
     </p>
     <p>
-      Teraz z konstruktywnej wersji chińskiego twierdzenia o resztach, możemy wyliczyć, że
-      $$x \equiv 1 \cdot 671 \cdot 2 + 10 \cdot 183 \cdot 8 + 10 \cdot 33 \cdot 37\ (mod\ 2013)$$
-      $$x \equiv 10\ (mod\ 2013)$$
+      Teraz z konstruktywnej wersji chińskiego twierdzenia o resztach, możemy
+      wyliczyć, że
+      $$
+      x \equiv 1 \cdot 671 \cdot 2 + 10 \cdot 183 \cdot 8 +
+      10 \cdot 33 \cdot 37\ (mod\ 2013)
+      $$
+      $$
+      x \equiv 10\ (mod\ 2013)
+      $$
     </p>
   </div>
 </div>
+
+---

--- a/_solutions/2013/2013-egzamin-2.md
+++ b/_solutions/2013/2013-egzamin-2.md
@@ -5,46 +5,54 @@ permalink: /2013/egzamin/2/
 
 ## 2013 Egzamin poprawkowy
 
-###Zadanie 1
+### Zadanie 1
 
-Udowodnij, że liczba \\(\frac{(kn)!}{k!(n!)^{k}}\\) jest całkowita dla dowolnych naturalnych \\(n\\) i \\(k\\).
+Udowodnij, że liczba \\(\frac{(kn)!}{k!(n!)^{k}}\\) jest całkowita dla
+dowolnych naturalnych \\(n\\) i \\(k\\).
 
 <div data-collapse>
   <h4 class="collapsible">Rozwiązanie</h4>
   <div class="solution">
     <p>
-      Oznaczmy \( p(n, k) \) jako liczbę podziałów zbioru n elementowego na bloki
-      zawierające dokładnie k elementów. W szczególności \( \forall_{n,k}\ p(n, k) \in \mathbb{Z} \).
+      Oznaczmy \( p(n, k) \) jako liczbę podziałów zbioru n elementowego na
+      bloki zawierające dokładnie k elementów. W szczególności
+      \( \forall_{n,k}\ p(n, k) \in \mathbb{Z} \).
     </p>
     <p>
       Pokażemy przez IK, że \((kn)! = p(kn, k)k!(n!)^k\).
     </p>
     <p>
-      <b>LEWA:</b> \((kn)!\) to liczba permutacji pól prostokąta o wymiarach \( k \times n \).
+      <b>LEWA:</b> \((kn)!\) to liczba permutacji pól prostokąta
+      o wymiarach \( k \times n \).
     </p>
     <p>
-      <b>PRAWA:</b> Dowolną permutacje pól takiego prostokąta możemy również uzyskać najpierw
-      wybierając z \(kn\) pól \(k\)-elementowe podzbiory (wiersze), następnie ustalić ich kolejność
-      na \(k!\) sposobów, a na koniec ustawić każdy z wierszy na \(n!\) sposobów, więc do iloczynu
+      <b>PRAWA:</b> Dowolną permutacje pól takiego prostokąta możemy również
+      uzyskać najpierw wybierając z \(kn\) pól \(k\)-elementowe podzbiory
+      (wiersze), następnie ustalić ich kolejność na \(k!\) sposobów, a na
+      koniec ustawić każdy z wierszy na \(n!\) sposobów, więc do iloczynu
       dojdzie czynnik \((n!)^k\).
     </p>
     <p>
-      Skoro pokazaliśmy, że powyższa równość jest prawdziwa, to możemy podzielić ją stronami
-      przez \(k!(n!)^k\) i wtedy otrzymamy:
-      $$\frac{(kn)!}{k!(n!)^k} = p(kn, k)$$
-      Ponieważ prawa strona na pewno jest liczbą całkowitą, to lewa także musi nią być.
+      Skoro pokazaliśmy, że powyższa równość jest prawdziwa, to możemy
+      podzielić ją stronami przez \(k!(n!)^k\) i wtedy otrzymamy:
+      $$
+      \frac{(kn)!}{k!(n!)^k} = p(kn, k)
+      $$
+      Ponieważ prawa strona na pewno jest liczbą całkowitą, to lewa także musi
+      nią być.
     </p>
   </div>
 </div>
 
-
 ---
 
-###Zadanie 2
+### Zadanie 2
 
-Graf jest *\\(k\\)-zdegenerowany*, jeśli każdy jego podgraf zawiera wierzchołek stopnia
-co najwyżej \\(k\\) (na przykład każdy graf planarny jest 5-zdegenerowany). Udowonij, że jeśli \\(G\\)
-jest spójnym 100-wierzchołkowym grafem 10-zdegenerowanym, to liczba wierzchołków stopnia \\(\geq 30\\) jest mniejsza niż 66.
+Graf jest *\\(k\\)-zdegenerowany*, jeśli każdy jego podgraf zawiera wierzchołek
+stopnia co najwyżej \\(k\\) (na przykład każdy graf planarny jest
+5-zdegenerowany). Udowonij, że jeśli \\(G\\) jest spójnym 100-wierzchołkowym
+grafem 10-zdegenerowanym, to liczba wierzchołków stopnia \\(\geq 30\\) jest
+mniejsza niż 66.
 
 *WSKAZÓWKA: Co można powiedzieć o średnim stopniu wierzchołka w \\(G\\)?*
 
@@ -52,22 +60,39 @@ jest spójnym 100-wierzchołkowym grafem 10-zdegenerowanym, to liczba wierzchoł
   <h4 class="collapsible">Rozwiązanie</h4>
   <div class="solution">
     <p>
-      Załóżmy, że mamy graf \(G\) będący grafem \(k\)-zdegenerowanym. Oznacza to, że ma on wierzchołek stopnia co najwyżej
-      \(k\). Możemy go z niego usunąć, a wtedy suma stopni wszystkich pozostałych wierzchołków spadnie o co najwyżej \(2k\) (k od usuwanego wierzchołka i k od jego sąsiadów).
-      W ten sposób otrzymujemy graf \(H \subset G\), ale z definicji \(k\)-zdegenerowania wynika, że on także posiada taki wierzchołek.
+      Załóżmy, że mamy graf \(G\) będący grafem \(k\)-zdegenerowanym. Oznacza
+      to, że ma on wierzchołek stopnia co najwyżej \(k\). Możemy go z niego
+      usunąć, a wtedy suma stopni wszystkich pozostałych wierzchołków spadnie
+      o co najwyżej \(2k\) (k od usuwanego wierzchołka i k od jego sąsiadów).
+      W ten sposób otrzymujemy graf \(H \subset G\), ale z definicji
+      \(k\)-zdegenerowania wynika, że on także posiada taki wierzchołek.
       Procedurę tę możemy kontynuować schodząc aż do grafu pustego.
     </p>
     <p>
-      Ponieważ przy każdej iteracji suma stopni wierzchołków
-      malała co najwyzej o \(k\), to możemy powiedzieć, że dla dowolnego grafu \(k\)-zdegenerowanego zachodzi: $$\sum_{i=1}^{\left|V(G)\right|} deg(v_i) \leq 2k\left|V(G)\right|$$
+      Ponieważ przy każdej iteracji suma stopni wierzchołków malała co najwyzej
+      o \(k\), to możemy powiedzieć, że dla dowolnego grafu
+      \(k\)-zdegenerowanego zachodzi:
+      $$
+      \sum_{i=1}^{\left|V(G)\right|} deg(v_i) \leq 2k\left|V(G)\right|
+      $$
       Przekształcając te nierówność otrzymujemy:
-      $$\frac{\sum_{i=1}^{\left|V(G)\right|} deg(v_i)}{\left|V(G)\right|} \leq 2k$$
-      czyli, w grafie \(k\) zdegenerowanym średni stopień wierzchołka nie może przekraczać \(k\).
+      $$
+      \frac{\sum_{i=1}^{\left|V(G)\right|} deg(v_i)}{\left|V(G)\right|} \leq
+      2k
+      $$,
+      czyli w grafie \(k\) zdegenerowanym średni stopień wierzchołka nie może
+      przekraczać \(k\).
     </p>
     <p>
-      Załóżmy teraz, że w grafie \(G\) liczba wierzchołków stopnia \( \geq 30\) jest większa niż 66. Mamy:
-      $$\frac{\sum_{i=1}^{\left|V(G)\right|} deg(v_i)}{\left|V(G)\right|} \geq \frac{66\cdot 30+34\cdot 1}{100} = 20.14 \geq 20 = 2k$$
-      (spójność grafu wymusza to, że pozostałe 34 wierzchołki musza mieć przynajmniej jedną krawędź), czyli graf \(G\) nie może być wtedy \(k\)-zdegenerowany.
+      Załóżmy teraz, że w grafie \(G\) liczba wierzchołków stopnia \( \geq 30\)
+      jest większa niż 66. Mamy:
+      $$
+      \frac{\sum_{i=1}^{\left|V(G)\right|} deg(v_i)}{\left|V(G)\right|} \geq
+      \frac{66\cdot 30+34\cdot 1}{100} = 20.14 \geq 20 = 2k
+      $$
+      (spójność grafu wymusza to, że pozostałe 34 wierzchołki musza mieć
+      przynajmniej jedną krawędź), czyli graf \(G\) nie może być wtedy
+      \(k\)-zdegenerowany.
     </p>
     <p>
       <b>Sprzeczność.</b>
@@ -77,11 +102,14 @@ jest spójnym 100-wierzchołkowym grafem 10-zdegenerowanym, to liczba wierzchoł
 
 ---
 
-###Zadanie 3
+### Zadanie 3
 
-Liczbę naturalną n nazywany *tegoroczną*, jeśli rozkłąd n na czynniki pierwsze zawiera czynnik,
-który występuje dokładnie w potędze 2013. Tak więc liczba \\(2^{2013}3^{5}\\) jest tegoroczna, ale liczba \\(5^{2014}7^{3000}\\) już nie (chociaż jest *przyszłoroczna*). Udowodnij,
-że istnieje ciąg arytmetyczny o 2013 elementach i różnicy ciągów równej 2013, którego wszystkie elementy są tegoroczne.
+Liczbę naturalną n nazywany *tegoroczną*, jeśli rozkłąd n na czynniki pierwsze
+zawiera czynnik, który występuje dokładnie w potędze 2013. Tak więc liczba
+\\(2^{2013}3^{5}\\) jest tegoroczna, ale liczba \\(5^{2014}7^{3000}\\) już nie
+(chociaż jest *przyszłoroczna*). Udowodnij, że istnieje ciąg arytmetyczny o
+2013 elementach i różnicy ciągów równej 2013, którego wszystkie elementy są
+tegoroczne.
 
 *WSKAZÓWKA: Chińskie twierdzenie o resztach.*
 
@@ -94,31 +122,39 @@ który występuje dokładnie w potędze 2013. Tak więc liczba \\(2^{2013}3^{5}\
     <p>
       Szukamy liczby a będącej początkiem takiego ciągu.
       Możemy ułożyć układ 2013 równań postaci:
-      $$(i)\ \ \ \ a \equiv -2013\cdot i\ (mod\ p_i)$$
-      $$\left\{
-          \begin{array}{lr}
-            a \equiv 0\ (mod \ p_{1}^{2013})\\
-            \ldots\\
-            a + 2013\cdot i \equiv 0\ (mod \ p_{i}^{2013})\\
-            \ldots\\
-            a + 2013\cdot 2013\equiv 0\ (mod \ p_{2013}^{2013})
-          \end{array}
-        \right.$$
+      $$
+      (i)\ \ \ \ a \equiv -2013\cdot i\ (mod\ p_i)
+      $$
+      $$
+      \left\{
+        \begin{array}{lr}
+          a \equiv 0\ (mod \ p_{1}^{2013})\\
+          \ldots\\
+          a + 2013\cdot i \equiv 0\ (mod \ p_{i}^{2013})\\
+          \ldots\\
+          a + 2013\cdot 2013\equiv 0\ (mod \ p_{2013}^{2013})
+        \end{array}
+      \right.
+      $$
       Co można przepisać jako:
-      $$\left\{
-          \begin{array}{lr}
-            a \equiv 0\ (mod \ p_{1}^{2013})\\
-            \ldots\\
-            a \equiv -2013\cdot i \ (mod \ p_{i}^{2013})\\
-            \ldots\\
-            a \equiv -2013\cdot 2013 \ (mod \ p_{2013}^{2013})\\
-          \end{array}
-        \right.$$
-      Ponieważ \(\forall_{i,j}\ i \neq j \Rightarrow p_i \perp p_j\), to również
-      \(\forall_{i,j}\ i \neq j \Rightarrow p_i^{2013} \perp p_j^{2013}\), a więc dzięki
-      chińskiemu twierdzeniu o resztach możemy powiedzieć, że istnieje dokładnie jedna liczba
-      \(a\) taka, że \(1 \leq a \leq p_1^{2013} \cdot \ldots \cdot p_{2013}^{2013}\) spełniająca
-      wszystkie powyższe kongruencje.
+      $$
+      \left\{
+        \begin{array}{lr}
+          a \equiv 0\ (mod \ p_{1}^{2013})\\
+          \ldots\\
+          a \equiv -2013\cdot i \ (mod \ p_{i}^{2013})\\
+          \ldots\\
+          a \equiv -2013\cdot 2013 \ (mod \ p_{2013}^{2013})\\
+        \end{array}
+      \right.
+      $$
+      Ponieważ \(\forall_{i,j}\ i \neq j \Rightarrow p_i \perp p_j\), to
+      również
+      \(\forall_{i,j}\ i \neq j \Rightarrow p_i^{2013} \perp p_j^{2013}\),
+      a więc dzięki chińskiemu twierdzeniu o resztach możemy powiedzieć, że
+      istnieje dokładnie jedna liczba \(a\) taka, że
+      \(1 \leq a \leq p_1^{2013} \cdot \ldots \cdot p_{2013}^{2013}\)
+      spełniająca wszystkie powyższe kongruencje.
     </p>
   </div>
 </div>

--- a/_solutions/2014/2014-egzamin-1.md
+++ b/_solutions/2014/2014-egzamin-1.md
@@ -5,10 +5,13 @@ permalink: /2014/egzamin/1/
 
 ## 2014 Pierwszy termin
 
-###Zadanie 1
+### Zadanie 1
+
 Udowodnij tożsamość
 
-$$\sum\_{k}{ n\brack k}{k\brace m} = {n\choose m}\frac{(n-1)!}{(m-1)!}$$
+$$
+\sum_{k}{ n\brack k}{k\brace m} = {n\choose m}\frac{(n-1)!}{(m-1)!}
+$$
 
 dla \\(n, m > 0\\)
 
@@ -16,43 +19,60 @@ dla \\(n, m > 0\\)
   <h4 class="collapsible">Rozwiązanie</h4>
   <div class="solution">
     <p>
-      <b>LEWA:</b> Dzielimy \(n\) elementów na \(k\) cykli, a następnie cykle dzielimy na
+      <b>LEWA:</b>
+      Dzielimy \(n\) elementów na \(k\) cykli, a następnie cykle dzielimy na
       zbiory tak, że żaden zbiór nie może być pusty.
     </p>
     <p>
-      <b>PRAWA:</b> Wybieramy \(m\) elementów, które będą początkami słów. Wyróżniamy jeden z nich
-      i stawiamy go na pierwszym miejscu, a następnie permutujemy pozostałe \(n-1\) elementów.
-      Następnie rozcinamy ten \(n\)-elementowy ciąg przed każdym z wybranych elementów i
-      otrzymujemy ciąg \(m\) słów. Podzielenie przez \(m!\) przekształca ten ciąg w zbiór \(m\) słów.
-      $${n\choose m}m\frac{(n-1)!}{m!} = {n\choose m}\frac{(n-1)!}{(m-1)!}$$
+      <b>PRAWA:</b> Wybieramy \(m\) elementów, które będą początkami słów.
+      Wyróżniamy jeden z nich i stawiamy go na pierwszym miejscu, a następnie
+      permutujemy pozostałe \(n-1\) elementów. Następnie rozcinamy ten
+      \(n\)-elementowy ciąg przed każdym z wybranych elementów i otrzymujemy
+      ciąg \(m\) słów. Podzielenie przez \(m!\) przekształca ten ciąg w zbiór
+      \(m\) słów.
+      $$
+      {n\choose m}m\frac{(n-1)!}{m!} = {n\choose m}\frac{(n-1)!}{(m-1)!}
+      $$
     </p>
     <p>
-      Żeby udowodnić tę równość wskażę bijekcje pomiędzy obiema stronami. Jeżeli mamy już dany jakiś
-      podział na cykle i ich zbiory, to popatrzmy na jeden ze zbiórów. Ustalmy że zapisujemy cykle tak,
-      że zawsze pierwszy element cyklu jest najmniejszy ze wszystkich, które do niego należą (tak jak w zapisie kanonicznym),
-      a w ramach całego zbioru ustawiamy je w kolejności malejącej względem pierwszego elementu.
-      Starcie wszystkich nawiasów wyznacza bijekcje między zbiorem cykli, a słowem.
-      $$(6)(358)(24) \mapsto 635824$$
-      W drugą stronę, jeżeli mamy dane jakieś słowo, to możemy odzyskać zbiór cykli w następujący sposób:
-      weźmy pierwszy element słowa i do jego cyklu dopisujmy po kolei następne elementy tak długo, aż
-      któryś z nich nie będzie większy niż pierwszy element. Kiedy napotkamy taki, to w tym momencie kończymy cykl
-      i powtarzamy procedurę zaczynając od napotkanego elementu.
-      $$635824 \mapsto (6)35824 \mapsto (6)(358)24 \mapsto (6)(358)(24)$$
+      Żeby udowodnić tę równość wskażę bijekcje pomiędzy obiema stronami.
+      Jeżeli mamy już dany jakiś podział na cykle i ich zbiory, to popatrzmy na
+      jeden ze zbiórów. Ustalmy że zapisujemy cykle tak, że zawsze pierwszy
+      element cyklu jest najmniejszy ze wszystkich, które do niego należą (tak
+      jak w zapisie kanonicznym), a w ramach całego zbioru ustawiamy je w
+      kolejności malejącej względem pierwszego elementu. Starcie wszystkich
+      nawiasów wyznacza bijekcje między zbiorem cykli, a słowem.
+      $$
+      (6)(358)(24) \mapsto 635824
+      $$
+      W drugą stronę, jeżeli mamy dane jakieś słowo, to możemy odzyskać zbiór
+      cykli w następujący sposób: weźmy pierwszy element słowa i do jego cyklu
+      dopisujmy po kolei następne elementy tak długo, aż któryś z nich nie
+      będzie większy niż pierwszy element. Kiedy napotkamy taki, to w tym
+      momencie kończymy cykl i powtarzamy procedurę zaczynając od napotkanego
+      elementu.
+      $$
+      635824 \mapsto (6)35824 \mapsto (6)(358)24 \mapsto (6)(358)(24)
+      $$
     </p>
+  </div>
 </div>
-</div>
-###Zadanie 2
-Znajdź liczbę 6-literowych słów złożonych z liter A, B, C, D, E w
-których: każda z liter A, B występuje _co najwyżej raz_, a każda z liter
-C, D - _co najmniej raz_.
+
+---
+
+### Zadanie 2
+
+Znajdź liczbę 6-literowych słów złożonych z liter \\(A\\), \\(B\\), \\(C\\),\\(D\\),
+\\(E\\), w których: każda z liter \\(A\\), \\(B\\) występuje _co najwyżej raz_,
+a każda z liter \\(C\\), \\(D\\) - _co najmniej raz_.
 
 <div data-collapse>
   <h4 class="collapsible">Rozwiązanie</h4>
   <div class="solution">
   <p>
-  Rozwiązanie oparte na rozwiązaniu zgłoszonym przez earlgreyz
-  w <a href="https://github.com/wakacjezmd/wakacjezmd.github.io/issues/13">
-  issue #13</a>
+    Rozwiązanie oparte na rozwiązaniu zgłoszonym przez earlgreyz
+    w <a href="https://github.com/wakacjezmd/wakacjezmd.github.io/issues/13">
+    issue #13</a>
   </p>
   <p>
     Użyjemy zasady włączeń i wyłączeń.
@@ -103,9 +123,12 @@ C, D - _co najmniej raz_.
   </div>
 </div>
 
-###Zadanie 3
+---
+
+### Zadanie 3
+
 Wierzchołki grafu \\(G\_n\\) to wszystkie liczby złożone ze zbioru
-\\({1,\dots,n}\)) a para \\({i,j}\\) jest krawędzią wtedy i tylko wtedy gdy
+\\({1,\dots,n}\\), a para \\({i,j}\\) jest krawędzią wtedy i tylko wtedy, gdy
 \\(i\perp j\\). Rozstrzygnij czy graf \\(G\_{1000}\\) jest:
 
 a) planarny
@@ -113,11 +136,11 @@ a) planarny
 <div data-collapse>
   <h4 class="collapsible">Rozwiązanie</h4>
   <div class="solution">
-     Nie, następujące względnie pierwsze liczby: 4, 9, 25, 36, 49
-     (kwadraty kolejnych liczb pierwszych)
-     tworzą klikę \(K_5\) co z tw.
-     Kuratowskiego oznacza że nie jest planarny.
-
+    <p>
+      Nie, następujące względnie pierwsze liczby: 4, 9, 25, 36, 49
+      (kwadraty kolejnych liczb pierwszych) tworzą klikę \(K_5\), co z tw.
+      Kuratowskiego oznacza że nie jest planarny.
+    </p>
   </div>
 </div>
 
@@ -126,18 +149,22 @@ b) hamiltonowski
 <div data-collapse>
   <h4 class="collapsible">Rozwiązanie</h4>
   <div class="solution">
-     <p>Skorzystam z twierdzenia o tym że jeżeli graf ma cykl hamiltona to
-     usunięcie k wierzchołków spowoduje jego rozpadnięcie się na co
-     najwyżej k składowych. </p>
-
-     <p>Mamy dokładnie 499 wierzchołków etykietowanych liczbami parzystymi i
-     zdecydowanie mniej wierzchołków nieparzystych (bo wiele spośród nich to
-     liczby pierwsze). Po usunięciu wierzchołków nieparzystych których jest
-     mniej niż 499 w grafie zostaje 499 wierzchołków parzystych które są
-     izolowane gdyż w ich rozkładzie na czynniki pierwsze jest 2.</p>
-
-     <p> Zatem nasz graf rozpadł się na 499 składowych i na mocy przytoczonego
-     twierdzenia nie może być hamiltonowski. </p>
+     <p>
+       Skorzystam z twierdzenia o tym że jeżeli graf ma cykl hamiltona, to
+       usunięcie k wierzchołków spowoduje jego rozpadnięcie się na co
+       najwyżej k składowych.
+    </p>
+     <p>
+       Mamy dokładnie 499 wierzchołków etykietowanych liczbami parzystymi i
+       zdecydowanie mniej wierzchołków nieparzystych (bo wiele spośród nich to
+       liczby pierwsze). Po usunięciu wierzchołków nieparzystych których jest
+       mniej niż 499 w grafie zostaje 499 wierzchołków parzystych które są
+       izolowane gdyż w ich rozkładzie na czynniki pierwsze jest 2.
+    </p>
+     <p>
+       Zatem nasz graf rozpadł się na 499 składowych i na mocy przytoczonego
+       twierdzenia nie może być hamiltonowski.
+    </p>
   </div>
 </div>
 
@@ -146,35 +173,54 @@ c) eulerowski
 <div data-collapse>
   <h4 class="collapsible">Rozwiązanie</h4>
   <div class="solution">
-     <p>Zbadajmy sąsiadów wierzchołka \(2\cdot 223\) (\(223\) to liczba pierwsza).
-        Są to wszystkie nieparzyste liczby złożone, oprócz \(3\cdot 223\).
-        Rozważmy teraz sąsiadów wierzchołka \(4\). Są to wszystkie nieparzyste
-        liczby złożone. W takim razie stopnie wierzchołków \(4\) i \(2\cdot 223\)
-        różnią się o \(1\), czyli jeden z nich musi być parzysty. W takim
-        razie graf nie jest eulerowski.</p>
+     <p>
+       Zbadajmy sąsiadów wierzchołka \(2\cdot 223\) (\(223\) to liczba
+       pierwsza). Są to wszystkie nieparzyste liczby złożone,
+       oprócz \(3\cdot 223\). Rozważmy teraz sąsiadów wierzchołka \(4\). Są to
+       wszystkie nieparzyste liczby złożone. W takim razie stopnie wierzchołków
+       \(4\) i \(2\cdot 223\) różnią się o \(1\), czyli jeden z nich musi być
+       parzysty. W takim razie graf nie jest eulerowski.
+    </p>
   </div>
 </div>
 
-###Zadanie 4
+---
 
-Uprość wyrażenie \\( \frac{1}{k!} \sum\limits\_{\pi \in S\_k} n^{c(\pi)}\\) gdzie \\(c(\pi)\\) to ilość cykli w permutacji \\(\pi\\).
+### Zadanie 4
+
+Uprość wyrażenie \\( \frac{1}{k!} \sum\limits\_{\pi \in S\_k} n^{c(\pi)}\\),
+gdzie \\(c(\pi)\\) to ilość cykli w permutacji \\(\pi\\).
+
 <div data-collapse>
   <h4 class="collapsible">Rozwiązanie</h4>
   <div class="solution">
     <p>
-	Grupując elementy podanej sumy na grupki permutacji o takich samych ilościach cykli uzyskujemy, że
-	$$ \sum\limits\_{\pi \in S\_k} n^{c(\pi)}=\\
-	  \sum\limits\_{i=1}^{k} {k \brack i} n^i   $$
-	Zauważmy, że ta suma zlicza nam ilość pokolorowań cykli wszystkich k-permutacji na n kolorów. <br><br>
-	Spróbujmy generować takie kolorowania w inny sposób - tworząc permutacje w zapisie kanonicznym cyklowym z kolorom przypisanym cyklom.
-	Elementy wstawiamy do cyklu w kolejności od najmniejszego do największego.
-	Wstawiając pierwszy element do permutacji może on być pokolorowany na jeden z \\(n\\) kolorów.
-	Drugi element może tworzyć nowy cykl i być pokolorowany na jeden z \\(n\\) kolorów,
-	bądź stać w cyklu na prawo od elementu pierwszego i mieć taki sam kolor jak on.
-	Łatwo widać że w takim wypadku daje nam to \\(n+1\\) możliwości. Uogólniając to rozumowanie, uzyskujemy następującą równość:
-	$$   \sum\limits\_{i=1}^{k} {k \brack i} n^i =  n^\overline{k} $$
-	Daje nam to odpowiedź:
-$$ 	\frac{1}{k!} \sum\limits\_{\pi \in S\_k} n^{c(\pi)} = \frac{n^\overline{k}}{k!} $$
-	 </p>
+      Grupując elementy podanej sumy na grupki permutacji o takich samej
+      liczbie cykli uzyskujemy, że
+      $$
+      \sum\limits_{\pi \in S\_k} n^{c(\pi)} =
+      \sum\limits_{i=1}^{k} {k \brack i} n^i
+      $$
+      Zauważmy, że ta suma zlicza nam ilość pokolorowań cykli wszystkich
+      \(k\)-permutacji na \(n\) kolorów.
+    </p>
+    <p>
+      Spróbujmy generować takie kolorowania w inny sposób - tworząc permutacje
+      w zapisie kanonicznym cyklowym z kolorom przypisanym cyklom. Elementy
+      wstawiamy do cyklu w kolejności od najmniejszego do największego.
+      Wstawiając pierwszy element do permutacji może on być pokolorowany na
+      jeden z \(n\) kolorów. Drugi element może tworzyć nowy cykl i być
+      pokolorowany na jeden z \(n\) kolorów, bądź stać w cyklu na prawo od
+      elementu pierwszego i mieć taki sam kolor jak on. Łatwo widać że w takim
+      wypadku daje nam to \(n+1\) możliwości. Uogólniając to rozumowanie,
+      uzyskujemy następującą równość:
+      $$
+      \sum\limits_{i=1}^{k} {k \brack i} n^i =  n^\overline{k}
+      $$
+      Daje nam to odpowiedź:
+      $$ \frac{1}{k!} \sum\limits_{\pi \in S_k} n^{c(\pi)} =
+      \frac{n^\overline{k}}{k!}
+      $$
+    </p>
   </div>
 </div>

--- a/_solutions/2014/2014-egzamin-2.md
+++ b/_solutions/2014/2014-egzamin-2.md
@@ -5,15 +5,17 @@ permalink: /2014/egzamin/2/
 
 ## 2014 Egzamin poprawkowy
 
-###Zadanie 1
+### Zadanie 1
+
 Uprość sumę
 $$
-\sum\limits^{k}\_{i=0} (-1)^i i \binom{n}{i}\binom{n}{k-i}
+\sum\limits^{k}_{i=0} (-1)^i i \binom{n}{i}\binom{n}{k-i}
 $$
 dla \\(n \geq k \geq \ 0\\).
 
 ---
-###Zadanie 2
+
+### Zadanie 2
 
 Udowodnij, że podziałów liczby \\(n\\) na cztery części jest tyle samo co
 podziałów liczby \\(3n\\) na cztery części rozmiaru co najwyżej \\(n - 1\\).
@@ -44,7 +46,8 @@ podziałów liczby \\(3n\\) na cztery części rozmiaru co najwyżej \\(n - 1\\)
 </div>
 
 ---
-###Zadanie 3
+
+### Zadanie 3
 
 Udowodnij, że w dowolnym kolorowaniu grafu \\(G\\) na \\(\chi(G)\\) kolorów
 istnieje wierzchołek każdego koloru, który ma sąsiadów we wszystkich pozostałych
@@ -66,12 +69,14 @@ kolorach.
       oznacza, że w nowym kolorowaniu kolor \(k\) nie będzie w ogóle użyty.
     </p>
     <p>
-    Zatem wyjściowe kolorowanie wcale nie używało minimalnej możliwej liczby
-    kolorów \(\chi(G)\).
+      Zatem wyjściowe kolorowanie wcale nie używało minimalnej możliwej liczby
+      kolorów \(\chi(G)\).
     </p>
   </div>
 </div>
 
 ---
 
-###Zadanie 4
+### Zadanie 4
+
+---

--- a/_solutions/2015/2015-egzamin-1.md
+++ b/_solutions/2015/2015-egzamin-1.md
@@ -5,7 +5,7 @@ permalink: /2015/egzamin/1/
 
 ## 2015 Pierwszy termin
 
-###Zadanie 1
+### Zadanie 1
 Udowodnij tożsamość
 
 $$\sum^{n}\_{k=0}k^m = \sum^{m}\_{k=1}{n+1 \choose k+1}{m\brace k}k! $$
@@ -44,19 +44,19 @@ takie, że \\(f(1) \gt f(i)\\) dla \\(i \gt 1\\).
 
 ---
 
-###Zadanie 2
+### Zadanie 2
 Niech \\(a\_n(k)\\) oznacza liczbę n-permutacji z powtórzeniami ze zbioru
 \\(\\left\\{1,...,k\\right\\}\\), w których k występuje nieparzystą liczbę razy.
 Znajdź zwarty wzór na \\(a\_n(k)\\) dla \\(k \gt 1\\).
 
 ---
 
-###Zadanie 3
+### Zadanie 3
 Znajdź wszystkie rozwiązania kongruencji \\(x^2 - 3x - 5\equiv 0\ (mod\ 343)\\).
 
 ---
 
-###Zadanie 4
+### Zadanie 4
 Znajdź liczbę istotnie różnych turniejów 5-wierzchołkowych, gdzie turnieje
 \\(T\\) i \\(T'\\) utożsamiamy, jeśli \\(T'\\) jest izomorficzny z
 \\(T\\) lub z turniejem otrzymanym z \\(T\\) przez odwrócenie kierunków

--- a/_solutions/2015/2015-egzamin-2.md
+++ b/_solutions/2015/2015-egzamin-2.md
@@ -5,15 +5,15 @@ permalink: /2015/egzamin/2/
 
 ## 2015 Egzamin poprawkowy
 
-###Zadanie 1
+### Zadanie 1
 
 ---
 
-###Zadanie 2
+### Zadanie 2
 
 ---
 
-###Zadanie 3
+### Zadanie 3
 Niech \\(G=(V,E)\\) będzie grafem takim, że \\(E=E\_1 \cup E\_2\\), gdzie graf
 \\(G\_1=(V, E\_1)\\) jest planarny, zaś graf \\(G\_2=(V, E\_2)\\) jest lasem.
 Udowodnij, że \\(\chi(G) < 9\\).
@@ -39,7 +39,7 @@ Udowodnij, że \\(\chi(G) < 9\\).
 
 ---
 
-###Zadanie 4
+### Zadanie 4
 
 Oblicz \\((1\cdot 3\cdot 5\dots 97)^2 \mod{101}\\).
 


### PR DESCRIPTION
GitHub informuje:

> The page build completed successfully, but returned the following warning:
> 
> You are currently using the 'redcarpet' Markdown engine, which is no longer supported by GitHub Pages and may cease working at any time. To ensure your site continues to build, remove the 'markdown' setting in your site's '_config.yml' file and confirm your site renders as expected. For more information, see https://help.github.com/articles/updating-your-markdown-processor-to-kramdown.
> 
> For information on troubleshooting Jekyll see:
> 
>  https://help.github.com/articles/troubleshooting-jekyll-builds

Przy okazji poprawiłem błędy stylu.
