### PR TITLE
2017 poprawki literówek + zmiana sposobu linkowania rozwiązania do stacka

### DIFF
--- a/_solutions/2017/2017-egzamin-1.md
+++ b/_solutions/2017/2017-egzamin-1.md
@@ -52,13 +52,8 @@ permalink: /2017/egzamin/1/
   wystąpić przynajmniej raz. Oblicz, na ile istotnie różnych sposobów można to zrobić, jeśli dwie macierze utożsamiamy, gdy jedną można otrzymać z drugiej strony przez pewną permutację wierszy i/lub kolumn.
 </p> 
 
-<div data-collapse>
-  <h4 class="collapsible">Rozwiązanie</h4>
-  <div class="solution">
-    <p>
-      Rozwiązanie jest dostępne <a href="https://math.stackexchange.com/questions/2113657/burnsides-lemma-applied-to-grids-with-interchanging-rows-and-columns">tutaj</a>.
-    </p>
-  </div>
+<div>
+  <h4 class="collapsible"><a href="https://math.stackexchange.com/questions/2113657/burnsides-lemma-applied-to-grids-with-interchanging-rows-and-columns">Rozwiązanie (link)</a></h4>
 </div>
 
 ---

--- a/_solutions/2017/2017-egzamin-1.md
+++ b/_solutions/2017/2017-egzamin-1.md
@@ -14,8 +14,8 @@ permalink: /2017/egzamin/1/
 ### Zadanie 2
 <p style="margin-bottom: 15px">
 
-  <i>Iloczyn Hadamarda</i> szeregów potęgowych \(A(x) = \sum_{n \geq 0} a_x x^n\) i 
-  \(B(x) = \sum_{n \geq 0} b_x x^n\) to szereg \(A(x) \bigodot B(x) = \sum_{n \geq 0} a_{b} b_{n} x^n\). Udowodnij, że jeśli \(A\) i \(B\) są 
+  <i>Iloczyn Hadamarda</i> szeregów potęgowych \(A(x) = \sum_{n \geq 0} a_n x^n\) i 
+  \(B(x) = \sum_{n \geq 0} b_n x^n\) to szereg \(A(x) \bigodot B(x) = \sum_{n \geq 0} a_{n} b_{n} x^n\). Udowodnij, że jeśli \(A\) i \(B\) są 
   funkcjami wymiernymi (czyli ilorazami wielomianów), to \(A \bigodot B\) też jest funkcją wymierną. 
   <i> Wskazówka:</i> jakie ciągi \( \langle a_{n} \rangle\) mają wymierną funkcję tworzącą \(A(x)\)?
 </p>
@@ -24,7 +24,7 @@ permalink: /2017/egzamin/1/
 ### Zadanie 3
 <p style="margin-bottom: 15px">
   Udowodnij, że jeśli \(m,n > 1\) i \(m \mid 2^n - 1\), to \(l(m) > l(n)\), gdzie \(l(x)\) oznacza <i> najmniejszy dzielnik pierwszy  </i> 
-  liczby \(x\). <i> Wskazówka: </i> Rozważ rząd elementu \(2\) w \(\mathbb{Z}_{t(m)}^*\).
+  liczby \(x\). <i> Wskazówka: </i> Rozważ rząd elementu \(2\) w \(\mathbb{Z}_{l(m)}^*\).
 </p> 
 
 
@@ -48,7 +48,7 @@ permalink: /2017/egzamin/1/
 
 ### Zadanie 4
 <p style="margin-bottom: 15px">
-  Macierz \(2x3\) wypełniamy liczbami ze zbioru \(\{1,2,3\}\), przy czym każda z liczb musi 
+  Macierz \(2 \times 3\) wypełniamy liczbami ze zbioru \(\{1,2,3\}\), przy czym każda z liczb musi 
   wystąpić przynajmniej raz. Oblicz, na ile istotnie różnych sposobów można to zrobić, jeśli dwie macierze utożsamiamy, gdy jedną można otrzymać z drugiej strony przez pewną permutację wierszy i/lub kolumn.
 </p> 
 


### PR DESCRIPTION
Jak w tytule. Rozwiązanie zadania 4 było rozwijanym polem, w którym był link do stacka. Teraz jest to po prostu link - jak w pozostałych egzaminach.